### PR TITLE
Changed U helpers generation

### DIFF
--- a/Assets/Prefabs/ULocation.prefab
+++ b/Assets/Prefabs/ULocation.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 607425771730979571}
   - component: {fileID: 3676035897964105867}
   m_Layer: 0
-  m_Name: Text (TMP)
+  m_Name: Back
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -214,6 +214,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6544588198236844087}
+  - {fileID: 4515398550365165694}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -266,3 +267,187 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8607052728106099841
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4515398550365165694}
+  - component: {fileID: 3559148456652471851}
+  - component: {fileID: 8369398990751835480}
+  - component: {fileID: 1667218515733665153}
+  m_Layer: 0
+  m_Name: Front
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4515398550365165694
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8607052728106099841}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0.501}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4914489971145780241}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!23 &3559148456652471851
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8607052728106099841}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &8369398990751835480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8607052728106099841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 00
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 7
+  m_fontSizeBase: 7
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 3559148456652471851}
+  m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+--- !u!65 &1667218515733665153
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8607052728106099841}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0.5}

--- a/Assets/Scripts/OgreeClasses/Slot.cs
+++ b/Assets/Scripts/OgreeClasses/Slot.cs
@@ -6,6 +6,7 @@ public class Slot : MonoBehaviour
 {
     public bool used = false;
     public string orient;
+    public bool isU;
     public string formFactor;
     public string labelPos;
 

--- a/Assets/Scripts/ReadFromJson.cs
+++ b/Assets/Scripts/ReadFromJson.cs
@@ -245,7 +245,7 @@ public class ReadFromJson
             if (_data.attributes != null && _data.attributes.ContainsKey("factor"))
                 s.formFactor = _data.attributes["factor"];
             s.labelPos = _data.labelPos;
-
+            s.isU = _data.type == "u";
             go.transform.GetChild(0).GetComponent<Collider>().enabled = false;
         }
         else

--- a/Assets/Scripts/UHelpersManager.cs
+++ b/Assets/Scripts/UHelpersManager.cs
@@ -203,12 +203,12 @@ public class UHelpersManager : MonoBehaviour
         _rack.uRoot.localEulerAngles = Vector3.zero;
         Vector3 boxSize = _rack.transform.GetChild(0).localScale;
         Transform URearLeft = new GameObject(cornerRearLeft).transform;
-        URearLeft.parent =_rack.uRoot;
+        URearLeft.parent = _rack.uRoot;
         URearLeft.localPosition = new Vector3(-boxSize.x / 2, 0, -boxSize.z / 2);
         Transform URearRight = new GameObject(cornerRearRight).transform;
         URearRight.parent = _rack.uRoot;
         URearRight.localPosition = new Vector3(boxSize.x / 2, 0, -boxSize.z / 2);
-        Transform UFrontLeft =new GameObject(cornerFrontLeft).transform;
+        Transform UFrontLeft = new GameObject(cornerFrontLeft).transform;
         UFrontLeft.parent = _rack.uRoot;
         UFrontLeft.localPosition = new Vector3(-boxSize.x / 2, 0, boxSize.z / 2);
         Transform UFrontRight = new GameObject(cornerFrontRight).transform;
@@ -220,10 +220,10 @@ public class UHelpersManager : MonoBehaviour
             scale = GameManager.instance.ouSize;
 
         //List<float> Uslotpositions = _rack.transform.Cast<Transform>().Where(t => t.GetComponent<Slot>() && t.GetComponent<Slot>().isU).Select(t => t.localPosition.y + 0.5f * (scale - t.GetChild(0).localScale.y)).Distinct().OrderBy(t => t).ToList();
-        float minY=float.PositiveInfinity;
-        float maxY=float.NegativeInfinity;
+        float minY = float.PositiveInfinity;
+        float maxY = float.NegativeInfinity;
 
-        foreach(Transform child in _rack.transform)
+        foreach (Transform child in _rack.transform)
         {
             Slot slot = child.GetComponent<Slot>();
             if (slot && slot.isU)

--- a/Assets/Scripts/UHelpersManager.cs
+++ b/Assets/Scripts/UHelpersManager.cs
@@ -1,6 +1,9 @@
 using UnityEngine;
 using TMPro;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
 
 public class UHelpersManager : MonoBehaviour
 {
@@ -81,9 +84,9 @@ public class UHelpersManager : MonoBehaviour
         if (oObject.category == "rack")
         {
             GameObject uRoot = rack.uRoot.gameObject;
-            uRoot.SetActive(true);
-            for (int i = 0; i < uRoot.transform.childCount; i++)
-                ChangeUColor(uRoot, i);
+            uRoot.SetActive(true);  
+            for (int i = 0; i < uRoot.transform.GetChild(0).childCount; i++)
+                ChangeUColor(uRoot, i,true);
             wasEdited = false;
         }
         else if (oObject.category == "device")
@@ -95,14 +98,11 @@ public class UHelpersManager : MonoBehaviour
             Transform t = GameManager.instance.GetSelected()[0].transform.GetChild(0);
             float center = t.position.y;
 
-            if (t.GetComponent<BoxCollider>().enabled)
-                difference = t.GetComponent<BoxCollider>().bounds.extents.y;
-            else
-            {
-                t.GetComponent<BoxCollider>().enabled = true;
-                difference = t.GetComponent<BoxCollider>().bounds.extents.y;
-                t.GetComponent<BoxCollider>().enabled = false;
-            }
+            BoxCollider boxCollider = t.GetComponent<BoxCollider>();
+            bool isEnabled = boxCollider.enabled;
+            boxCollider.enabled = true;
+            difference = boxCollider.bounds.extents.y;
+            boxCollider.enabled = isEnabled;
 
             t = GameManager.instance.GetSelected()[0].transform;
             float delta = t.localPosition.y - t.GetComponent<OgreeObject>().originalLocalPosition.y;
@@ -111,14 +111,11 @@ public class UHelpersManager : MonoBehaviour
 
             GameObject uRoot = rack.GetComponent<Rack>().uRoot.gameObject;
             uRoot.SetActive(true);
-            for (int i = 0; i < uRoot.transform.childCount; i++)
+            for (int i = 0; i < uRoot.transform.GetChild(0).childCount; i++)
             {
-                if (lowerBound < uRoot.transform.GetChild(i).position.y && uRoot.transform.GetChild(i).position.y < upperBound)
-                    ChangeUColor(uRoot, i);
-                else
-                    uRoot.transform.GetChild(i).gameObject.GetComponent<MeshRenderer>().material.color = Color.black;
+                Transform u = uRoot.transform.GetChild(0).GetChild(i);
+                ChangeUColor(uRoot, i, lowerBound < u.position.y && u.position.y < upperBound);
             }
-            return;
         }
     }
 
@@ -127,17 +124,17 @@ public class UHelpersManager : MonoBehaviour
     /// </summary>
     /// <param name="_uRoot">Root transform of U helpers</param>
     /// <param name="_index">U helper index</param>
-    private void ChangeUColor(GameObject _uRoot, int _index)
+    /// <param name="_activated">If the U helper is colored or not</param>
+    private void ChangeUColor(GameObject _uRoot, int _index, bool _activated)
     {
-        GameObject obj = _uRoot.transform.GetChild(_index).gameObject;
-        if (obj.name.StartsWith(cornerRearLeft))
-            obj.GetComponent<Renderer>().material.color = Color.red;
-        if (obj.name.StartsWith(cornerRearRight))
-            obj.GetComponent<Renderer>().material.color = Color.yellow;
-        if (obj.name.StartsWith(cornerFrontLeft))
-            obj.GetComponent<Renderer>().material.color = Color.blue;
-        if (obj.name.StartsWith(cornerFrontRight))
-            obj.GetComponent<Renderer>().material.color = Color.green;
+        GameObject obj = _uRoot.transform.GetChild(0).GetChild(_index).gameObject;
+        obj.GetComponent<Renderer>().material.color = _activated ? Color.red : Color.black;
+        obj = _uRoot.transform.GetChild(1).GetChild(_index).gameObject;
+        obj.GetComponent<Renderer>().material.color = _activated ? Color.yellow : Color.black;
+        obj = _uRoot.transform.GetChild(2).GetChild(_index).gameObject;
+        obj.GetComponent<Renderer>().material.color = _activated ? Color.blue : Color.black;
+        obj = _uRoot.transform.GetChild(3).GetChild(_index).gameObject;
+        obj.GetComponent<Renderer>().material.color = _activated ? Color.green : Color.black;
     }
 
     ///<summary>
@@ -159,9 +156,8 @@ public class UHelpersManager : MonoBehaviour
             else
                 uRoot.gameObject.SetActive(true);
         }
-        else if (!_active && uRoot)
+        else if (uRoot)
             uRoot.gameObject.SetActive(false);
-        return;
     }
 
     ///<summary>
@@ -180,7 +176,7 @@ public class UHelpersManager : MonoBehaviour
             GenerateUHelpers(_transform.GetComponent<Rack>());
             GameManager.instance.AppendLogLine($"U helpers ON for {_transform.name}.", ELogTarget.logger, ELogtype.info);
         }
-        else if (uRoot.gameObject.activeSelf == false)
+        else if (!uRoot.gameObject.activeSelf)
         {
             uRoot.gameObject.SetActive(true);
             GameManager.instance.AppendLogLine($"U helpers ON for {_transform.name}.", ELogTarget.logger, ELogtype.info);
@@ -190,115 +186,54 @@ public class UHelpersManager : MonoBehaviour
             uRoot.gameObject.SetActive(false);
             GameManager.instance.AppendLogLine($"U helpers OFF for {_transform.name}.", ELogTarget.logger, ELogtype.info);
         }
-        return;
     }
 
     ///<summary>
-    /// Create uRoot, place it and call <see cref="GenerateUColumn"/> for each corner
+    /// Create uRoot, place it and create U helpers for each corner
     ///</summary>
     ///<param name="_rack">The rack where we create the U helpers</param>
     public void GenerateUHelpers(Rack _rack)
     {
         if (_rack.uRoot)
             return;
-        Vector3 rootPos;
-        Transform box = _rack.transform.GetChild(0);
-        if (box.childCount == 0)
-            rootPos = new Vector3(0, box.localScale.y / -2, 0);
-        else
-            rootPos = new Vector3(0, box.GetComponent<BoxCollider>().size.y / -2, 0);
 
         _rack.uRoot = new GameObject("uRoot").transform;
         _rack.uRoot.parent = _rack.transform;
-        _rack.uRoot.localPosition = rootPos;
+        _rack.uRoot.localPosition = Vector3.zero;
         _rack.uRoot.localEulerAngles = Vector3.zero;
-        GenerateUColumn(_rack, cornerRearLeft);
-        GenerateUColumn(_rack, cornerRearRight);
-        GenerateUColumn(_rack, cornerFrontLeft);
-        GenerateUColumn(_rack, cornerFrontRight);
-    }
-
-    ///<summary>
-    /// Instantiate one <see cref="GameManager.uLocationModel"/> per U in the given column
-    ///</summary>
-    ///<param name="_corner">Corner of the column</param>
-    ///<param name="_rack">The rack where we create the U helpers</param>
-    private void GenerateUColumn(Rack _rack, string _corner)
-    {
         Vector3 boxSize = _rack.transform.GetChild(0).localScale;
+        Transform URearLeft = Instantiate(new GameObject(cornerRearLeft), _rack.uRoot).transform;
+        URearLeft.localPosition = new Vector3(-boxSize.x / 2, 0, -boxSize.z / 2);
+        Transform URearRight = Instantiate(new GameObject(cornerRearRight), _rack.uRoot).transform;
+        URearRight.localPosition = new Vector3(boxSize.x / 2, 0, -boxSize.z / 2);
+        Transform UFrontLeft = Instantiate(new GameObject(cornerFrontLeft),_rack.uRoot).transform;
+        UFrontLeft.localPosition = new Vector3(-boxSize.x / 2, 0, boxSize.z / 2);
+        Transform UFrontRight = Instantiate(new GameObject(cornerFrontRight), _rack.uRoot).transform;
+        UFrontRight.localPosition = new Vector3(boxSize.x / 2, 0, boxSize.z / 2);
 
-        // By default, attributes["heightUnit"] == "U"
         float scale = GameManager.instance.uSize;
-        int max = (int)Utils.ParseDecFrac(_rack.attributes["height"]);
         if (_rack.attributes["heightUnit"] == "OU")
             scale = GameManager.instance.ouSize;
-        else if (_rack.attributes["heightUnit"] == "cm")
-            max = Mathf.FloorToInt(Utils.ParseDecFrac(_rack.attributes["height"]) / (GameManager.instance.uSize * 100));
 
-        if (!string.IsNullOrEmpty(_rack.attributes["template"]))
+        List<float> Uslotpositions = _rack.transform.Cast<Transform>().Where(t => t.GetComponent<Slot>() && t.GetComponent<Slot>().isU).Select(t=>t.localPosition.y).Distinct().OrderBy(t => t).ToList();
+        if (Uslotpositions.Count > 0)
         {
-            Transform firstSlot = null;
-            int minHeight = 0;
-            foreach (Transform child in _rack.transform)
-            {
-                if (child.GetComponent<Slot>() && child.GetComponent<Slot>().orient == "horizontal")
-                {
-                    if (firstSlot)
-                    {
-                        // Should use position.y instead of its name
-                        int height = GetUNumberFromName(child.name);
-                        if (height < minHeight)
-                            firstSlot = child;
-                        else if (height > max)
-                            max = height;
-                    }
-                    else
-                    {
-                        firstSlot = child;
-                        minHeight = GetUNumberFromName(child.name);
-                        max = minHeight;
-                    }
-                }
-            }
-            if (firstSlot)
-            {
-                _rack.uRoot.localPosition = new Vector3(_rack.uRoot.localPosition.x, firstSlot.localPosition.y, _rack.uRoot.localPosition.z);
-                _rack.uRoot.localPosition -= new Vector3(0, firstSlot.GetChild(0).localScale.y / 2, 0);
-            }
+            for (int i = 0; i < Uslotpositions.Count; i++)
+                BuildU(Uslotpositions[i], i + 1, scale, URearLeft, URearRight, UFrontLeft, UFrontRight);
         }
-        for (int i = 1; i <= max; i++)
+        else if (_rack.attributes.ContainsKey("sizeWDHu") || _rack.attributes.ContainsKey("sizeWDHou") || _rack.attributes["heightUnit"] == "U" || _rack.attributes["heightUnit"] == "OU")
         {
-            Transform obj = Instantiate(GameManager.instance.uLocationModel).transform;
-            obj.name = $"{_corner}_u{i}";
-            obj.GetComponentInChildren<TextMeshPro>().text = i.ToString();
-            obj.parent = _rack.uRoot;
-            obj.localScale = Vector3.one * scale;
-            if (_corner == cornerRearLeft)
-            {
-                obj.localPosition = new Vector3(-boxSize.x / 2, i * scale - scale / 2, -boxSize.z / 2);
-                obj.localEulerAngles = new Vector3(0, 0, 0);
-                obj.GetComponent<Renderer>().material.color = Color.red;
-            }
-            else if (_corner == cornerRearRight)
-            {
-                obj.localPosition = new Vector3(boxSize.x / 2, i * scale - scale / 2, -boxSize.z / 2);
-                obj.localEulerAngles = new Vector3(0, 0, 0);
-                obj.GetComponent<Renderer>().material.color = Color.yellow;
-            }
-            else if (_corner == cornerFrontLeft)
-            {
-                obj.localPosition = new Vector3(-boxSize.x / 2, i * scale - scale / 2, boxSize.z / 2);
-                obj.localEulerAngles = new Vector3(0, 180, 0);
-                obj.GetComponent<Renderer>().material.color = Color.blue;
-            }
-            else if (_corner == cornerFrontRight)
-            {
-                obj.localPosition = new Vector3(boxSize.x / 2, i * scale - scale / 2, boxSize.z / 2);
-                obj.localEulerAngles = new Vector3(0, 180, 0);
-                obj.GetComponent<Renderer>().material.color = Color.green;
-            }
+            int Unumber;
+            if (_rack.attributes.ContainsKey("sizeWDHu"))
+                Unumber = JsonConvert.DeserializeObject<int[]>(_rack.attributes["sizeWDHu"])[2];
+            else if (_rack.attributes.ContainsKey("sizeWDHou"))
+                Unumber = JsonConvert.DeserializeObject<int[]>(_rack.attributes["sizeWDHou"])[2];
             else
-                Debug.LogError("Unkown Corner");
+                Unumber = int.Parse(_rack.attributes["height"]);
+
+            float offset = - (Unumber-1) * scale / 2;
+            for (int i = 0; i < Unumber; i++)
+                BuildU((offset + i * scale), i + 1, scale, URearLeft, URearRight, UFrontLeft, UFrontRight);
         }
     }
 
@@ -317,24 +252,43 @@ public class UHelpersManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Get the U number from the name of a U helper cube
+    /// Build one floor of the four U-helpers columns
     /// </summary>
-    /// <param name="_name">the name of the U helper</param>
-    /// <returns>The number of the U helper</returns>
-    private int GetUNumberFromName(string _name)
+    /// <param name="_positionY">(local) vertical position of the floor</param>
+    /// <param name="_number">number of the floor</param>
+    /// <param name="_scale">height of the floor (u size or ou size)</param>
+    /// <param name="_URearLeft">parent of the rear-left column</param>
+    /// <param name="_URearRight">parent of the rear-right column</param>
+    /// <param name="_UFrontLeft">parent of the front-left column</param>
+    /// <param name="_UFrontRight">parent of the front-right column</param>
+    private void BuildU(float _positionY, int _number, float _scale, Transform _URearLeft, Transform _URearRight, Transform _UFrontLeft, Transform _UFrontRight)
     {
-        string iteratedName = _name;
-        while (iteratedName.Length > 0)
-        {
-            try
-            {
-                return (int)Utils.ParseDecFrac(iteratedName);
-            }
-            catch (FormatException)
-            {
-                iteratedName = iteratedName.Substring(1);
-            }
-        }
-        return 0;
+        Transform rearLeft = Instantiate(GameManager.instance.uLocationModel, _URearLeft).transform;
+        rearLeft.localPosition = _positionY * Vector3.up;
+        rearLeft.name = $"{cornerRearLeft}_u{_number}";
+        rearLeft.GetComponentInChildren<TextMeshPro>().text = _number.ToString();
+        rearLeft.localScale = Vector3.one * _scale;
+        rearLeft.GetComponent<Renderer>().material.color = Color.red;
+
+        Transform rearRight = Instantiate(GameManager.instance.uLocationModel, _URearRight).transform;
+        rearRight.localPosition = _positionY * Vector3.up;
+        rearRight.name = $"{cornerRearRight}_u{_number}";
+        rearRight.GetComponentInChildren<TextMeshPro>().text = _number.ToString();
+        rearRight.localScale = Vector3.one * _scale;
+        rearRight.GetComponent<Renderer>().material.color = Color.yellow;
+
+        Transform frontLeft = Instantiate(GameManager.instance.uLocationModel,_UFrontLeft).transform;
+        frontLeft.localPosition = _positionY * Vector3.up;
+        frontLeft.name = $"{cornerFrontLeft}_u{_number}";
+        frontLeft.GetComponentInChildren<TextMeshPro>().text = _number.ToString();
+        frontLeft.localScale = Vector3.one * _scale;
+        frontLeft.GetComponent<Renderer>().material.color = Color.blue;
+
+        Transform frontRight = Instantiate(GameManager.instance.uLocationModel, _UFrontRight).transform;
+        frontRight.localPosition = _positionY * Vector3.up;
+        frontRight.name = $"{cornerFrontRight}_u{_number}";
+        frontRight.GetComponentInChildren<TextMeshPro>().text = _number.ToString();
+        frontRight.localScale = Vector3.one * _scale;
+        frontRight.GetComponent<Renderer>().material.color = Color.green;
     }
 }


### PR DESCRIPTION
Check if there are slots of type "u" in the rack
    - ✅ : build a u helper at the elevation of the slot for each slots of type "u". When the template doesn't have all u slots, U helpers columns start at the bottom of the lowest u slot, then grow until they get to the top of the highest u slot (they don't go past it)
    - ⛔ : check for "sizeWDHu", "sizeWDHou", or "heightUnit" == "u" or "ou", then build as many u helpers as stated in "sizeWDhu", "sizeWDHou" or "height"