### PR TITLE
Get objects on highlight

### DIFF
--- a/Assets/Scripts/Network/ApiManager.cs
+++ b/Assets/Scripts/Network/ApiManager.cs
@@ -425,7 +425,7 @@ public class ApiManager : MonoBehaviour
             GameManager.instance.AppendLogLine(new ExtendedLocalizedString("Logs", "From API", responseStr), ELogTarget.none, ELogtype.infoApi);
 
             if (responseStr.Contains("success"))
-                await CreateItemFromJson(responseStr);
+                await CreateObjectFromJson(responseStr);
             else
                 GameManager.instance.AppendLogLine(new LocalizedString("Logs", "Fail to post on server"), ELogTarget.logger, ELogtype.errorApi);
         }
@@ -503,7 +503,7 @@ public class ApiManager : MonoBehaviour
                 EventManager.instance.Raise(new ChangeCursorEvent(CursorChanger.CursorType.Loading));
             }
             else
-                await CreateItemFromJson(_input);
+                await CreateObjectFromJson(_input);
         }
         catch (Exception e)
         {
@@ -511,12 +511,35 @@ public class ApiManager : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Attemps to draw an object or it's parent if not already drawn. <b>Given "data" must be an array</b>
+    /// </summary>
+    /// <param name="_input"></param>
+    public async Task DrawObjectAndParents(string _input)
+    {
+        string dataStr = JsonConvert.DeserializeObject<Hashtable>(_input)["data"].ToString();
+        List<SApiObject> objects = JsonConvert.DeserializeObject<List<SApiObject>>(dataStr);
+        await OgreeGenerator.instance.CreateOrGetParent(objects[0]);
+    }
+
+    /// <summary>
+    /// Give a <see cref="SApiObject"/> from received data. <b>Given "data" must be an array</b>
+    /// </summary>
+    /// <param name="_input"></param>
+    /// <returns>The first SApiObject received</returns>
+    public Task<SApiObject> GetSApiObject(string _input)
+    {
+        string dataStr = JsonConvert.DeserializeObject<Hashtable>(_input)["data"].ToString();
+        List<SApiObject> objects = JsonConvert.DeserializeObject<List<SApiObject>>(dataStr);
+        return Task.Run(() => objects[0]);
+    }
+
     ///<summary>
-    /// Create an Ogree item from Json.
+    /// Create an Ogree object from Json.
     /// Look in request path to the type of object to create
     ///</summary>
     ///<param name="_json">The API response to use</param>
-    private async Task CreateItemFromJson(string _json)
+    private async Task CreateObjectFromJson(string _json)
     {
         List<SApiObject> physicalObjects = new();
         List<SApiObject> logicalObjects = new();

--- a/Assets/Scripts/Network/CommandParser.cs
+++ b/Assets/Scripts/Network/CommandParser.cs
@@ -436,10 +436,11 @@ public class CommandParser
                 break;
             case Command.Highlight:
                 GameObject obj = Utils.GetObjectById(manip.data);
-                if (obj)
-                    EventManager.instance.Raise(new HighlightEvent(obj));
-                else
-                    GameManager.instance.AppendLogLine(new LocalizedString("Logs", "Error on highlight"), ELogTarget.both, ELogtype.errorCli);
+                if (!obj)
+                    await ApiManager.instance.GetObject($"objects?id={manip.data}", ApiManager.instance.DrawObjectAndParents);
+                while (OgreeGenerator.instance.isDrawing)
+                    await Task.Delay(10);
+                EventManager.instance.Raise(new HighlightEvent(Utils.GetObjectById(manip.data)));
                 break;
             case Command.ClearCache:
                 if (GameManager.instance.objectRoot)

--- a/Assets/Scripts/Network/CommandParser.cs
+++ b/Assets/Scripts/Network/CommandParser.cs
@@ -273,7 +273,7 @@ public class CommandParser
 
         // Get domain from API if new domain isn't loaded
         if (!string.IsNullOrEmpty(newData.domain) && !GameManager.instance.allItems.Contains(newData.domain))
-            await ApiManager.instance.GetObject($"domains/{newData.domain}", ApiManager.instance.DrawObject);
+            await ApiManager.instance.GetObject($"domains/{newData.domain}", ApiManager.instance.CreateObjectFromJson);
 
         // Case domain for all OgreeObjects
         bool domainColorChanged = newData.category == Category.Domain && obj.attributes["color"] != newData.attributes["color"];
@@ -437,7 +437,7 @@ public class CommandParser
             case Command.Highlight:
                 GameObject obj = Utils.GetObjectById(manip.data);
                 if (!obj)
-                    await ApiManager.instance.GetObject($"objects?id={manip.data}", ApiManager.instance.DrawObjectAndParents);
+                    await ApiManager.instance.GetObject($"objects?id={manip.data}", ApiManager.instance.CreateObjectAndParents);
                 while (OgreeGenerator.instance.isDrawing)
                     await Task.Delay(10);
                 EventManager.instance.Raise(new HighlightEvent(Utils.GetObjectById(manip.data)));

--- a/Assets/Scripts/OgreeClasses/OgreeObject.cs
+++ b/Assets/Scripts/OgreeClasses/OgreeObject.cs
@@ -132,7 +132,7 @@ public class OgreeObject : MonoBehaviour, IComparable<OgreeObject>
         if (currentLod > _level)
             await DeleteChildren(_level);
         else if (_level != currentLod)
-            await ApiManager.instance.GetObject($"{category}s/{id}/all?limit={_level}", ApiManager.instance.DrawObject);
+            await ApiManager.instance.GetObject($"{category}s/{id}/all?limit={_level}", ApiManager.instance.CreateObjectFromJson);
 
         SetCurrentLod(_level);
     }

--- a/Assets/Scripts/OgreeGenerators/OgreeGenerator.cs
+++ b/Assets/Scripts/OgreeGenerators/OgreeGenerator.cs
@@ -41,28 +41,28 @@ public class OgreeGenerator : MonoBehaviour
         // Domains
         if (_obj.category != Category.Domain && !string.IsNullOrEmpty(_obj.domain)
             && !GameManager.instance.allItems.Contains(_obj.domain))
-            await ApiManager.instance.GetObject($"domains/{_obj.domain}", ApiManager.instance.DrawObject);
+            await ApiManager.instance.GetObject($"domains/{_obj.domain}", ApiManager.instance.CreateObjectFromJson);
 
         // Templates
         if (_obj.category == Category.Building && _obj.attributes.HasKeyAndValue("template")
             && !GameManager.instance.buildingTemplates.ContainsKey((string)_obj.attributes["template"]))
         {
             Debug.Log($"Get template \"{_obj.attributes["template"]}\" from API");
-            await ApiManager.instance.GetObject($"bldg-templates/{_obj.attributes["template"]}", ApiManager.instance.DrawObject);
+            await ApiManager.instance.GetObject($"bldg-templates/{_obj.attributes["template"]}", ApiManager.instance.CreateTemplateFromJson);
         }
 
         if (_obj.category == Category.Room && _obj.attributes.HasKeyAndValue("template")
             && !GameManager.instance.roomTemplates.ContainsKey((string)_obj.attributes["template"]))
         {
             Debug.Log($"Get template \"{_obj.attributes["template"]}\" from API");
-            await ApiManager.instance.GetObject($"room-templates/{_obj.attributes["template"]}", ApiManager.instance.DrawObject);
+            await ApiManager.instance.GetObject($"room-templates/{_obj.attributes["template"]}", ApiManager.instance.CreateTemplateFromJson);
         }
 
         if ((_obj.category == Category.Rack || _obj.category == Category.Device || _obj.category == Category.Generic) && _obj.attributes.HasKeyAndValue("template")
             && !GameManager.instance.objectTemplates.ContainsKey((string)_obj.attributes["template"]))
         {
             Debug.Log($"Get template \"{_obj.attributes["template"]}\" from API");
-            await ApiManager.instance.GetObject($"obj-templates/{_obj.attributes["template"]}", ApiManager.instance.DrawObject);
+            await ApiManager.instance.GetObject($"obj-templates/{_obj.attributes["template"]}", ApiManager.instance.CreateTemplateFromJson);
         }
 
         // Tags
@@ -186,7 +186,7 @@ public class OgreeGenerator : MonoBehaviour
     {
         if (!(string.IsNullOrEmpty(_obj.parentId) || Utils.GetObjectById(_obj.parentId)))
         {
-            SApiObject parent = await ApiManager.instance.GetObject($"objects?id={_obj.parentId}", ApiManager.instance.GetSApiObject);
+            SApiObject parent = (await ApiManager.instance.GetObject($"objects?id={_obj.parentId}", ApiManager.instance.GetSApiObjects))[0];
             await CreateOrGetParent(parent);
         }
         await CreateItemFromSApiObject(_obj);


### PR DESCRIPTION
- When receiving a Highlight command, the client get targeted object and all its parents (if not already drawn). Then highlight targeted object.
- Reorganize callback methods in ApiManager to split `DrawObject` into different methods: one for objects, one for templates